### PR TITLE
Allows empty basePath in configuration

### DIFF
--- a/src/js/url-builder.js
+++ b/src/js/url-builder.js
@@ -31,11 +31,11 @@ URLBuilder.prototype = {
 
         var config = this._configParser.getConfig();
 
-        var basePath = config.basePath;
+        var basePath = config.basePath || '';
         var registeredModules = this._configParser.getModules();
 
         /* istanbul ignore else */
-        if (basePath.charAt(basePath.length - 1) !== '/') {
+        if (basePath.length && basePath.charAt(basePath.length - 1) !== '/') {
             basePath += '/';
         }
 


### PR DESCRIPTION
I ran into an issue about my comboloader configuration where my js files are asked with just their names: 
http://my-combo-host/kendo/2015.3.1111?kendo.core.min.js
So in my configuration basePath had to be '' (empty string), but a trailing slash is being added.
With this patch I have url-builder to check if basePath is not an empty string before adding the trailing slash.