### PR TITLE
Global eval scripts using head instead of body

### DIFF
--- a/src/js/script-loader.js
+++ b/src/js/script-loader.js
@@ -537,12 +537,12 @@ var LoaderProtoMethods = {
 
             // If some script fails to load, reject the main Promise
             script.onerror = function() {
-                document.body.removeChild(script);
+                document.head.removeChild(script);
 
                 reject(script);
             };
 
-            document.body.appendChild(script);
+            document.head.appendChild(script);
         });
     },
 

--- a/test/fixture/script.js
+++ b/test/fixture/script.js
@@ -24,7 +24,7 @@ Script.prototype = {
 };
 
 var document = {
-    body: {
+    head: {
         appendChild: function (script) {
             process.nextTick(function () {
                 script.load();


### PR DESCRIPTION
- Relevant to allow require() to be used from inside head element