### PR TITLE
Allow mismatched anonymous module report log level to be configured

### DIFF
--- a/src/js/script-loader.js
+++ b/src/js/script-loader.js
@@ -94,13 +94,13 @@ var LoaderProtoMethods = {
                 self.off('scriptLoaded', onScriptLoaded);
 
                 if (loadedModules.length !== 1) {
-                    throw new Error('Mismatched anonymous define() module: ' + implementation.toString());
+                    self._reportMismatchedAnonymousModules(implementation.toString());
                 } else {
                     var moduleName = loadedModules[0];
                     var module = self.getModules()[moduleName];
 
                     if (module && module.pendingImplementation) {
-                        throw new Error('Mismatched anonymous define() module: '  + implementation.toString());
+                        self._reportMismatchedAnonymousModules(implementation.toString());
                     }
 
                     self._define(moduleName, dependencies, implementation, config);
@@ -636,6 +636,24 @@ var LoaderProtoMethods = {
                 reject(error);
             }
         });
+    },
+
+    /**
+     * Reports a mismatched anonymous module error. Depending on the value of the configuration property
+     * `__CONFIG__.reportMismatchedAnonymousModules`, this method will throw an error, use the console[level]
+     * method to log the message or silently ignore it.
+     *
+     * @param  {string} msg Additional information to log with the error.
+     */
+    _reportMismatchedAnonymousModules: function(msg) {
+        var errorMessage = 'Mismatched anonymous define() module: ' + msg;
+        var reportLevel = this._config.reportMismatchedAnonymousModules;
+
+        if (!reportLevel || reportLevel === 'exception') {
+            throw new Error(errorMessage);
+        } else if (console && console[reportLevel]) {
+            console[reportLevel].call(console, errorMessage);
+        }
     },
 
     /**


### PR DESCRIPTION
Hey @ipeychev, this adds the configurable log level for `mismatched anonymous modules`. The behaviour will be as follow:

```javascript
// By default, if not configured, will throw an exception

// Throw an exception
__CONFIG__.reportMismatchedAnonymousModules = 'exception';

// Log the error using console.log
__CONFIG__.reportMismatchedAnonymousModules = 'log';

// Log the error using console.info
__CONFIG__.reportMismatchedAnonymousModules = 'info';

// Log the error using console.warn
__CONFIG__.reportMismatchedAnonymousModules = 'warn';

// Log the error using console.error
__CONFIG__.reportMismatchedAnonymousModules = 'error';

// Ignore the error
__CONFIG__.reportMismatchedAnonymousModules = 'off';
```