### PR TITLE
SF - Remove invalid whitespace character

### DIFF
--- a/src/js/script-loader.js
+++ b/src/js/script-loader.js
@@ -651,7 +651,7 @@ var LoaderProtoMethods = {
         var errorMessage = 'Mismatched anonymous define() module: ' + msg;
         var reportLevel = this._config.reportMismatchedAnonymousModules;
 
-        if (!reportLevel || reportLevel === 'exception') {
+        if (!reportLevel || reportLevel === 'exception') {
             throw new Error(errorMessage);
         } else if (console && console[reportLevel]) {
             // Call console's method by using the `call` function


### PR DESCRIPTION
Hey @ipeychev, this happened to me again 😢 and breaks the loader in windows systems if used in conjunction with a minifier.

I've tracked it down to some snippet I had in the system, so hopefully I won't bother you again with this.

Could you please merge and release 1.5.2 with this fix?

Thanks!