### PR TITLE
Fixes generated paths for modules with `.js` inside their path

### DIFF
--- a/src/js/url-builder.js
+++ b/src/js/url-builder.js
@@ -191,7 +191,7 @@ URLBuilder.prototype = {
             path = paths['*'](path);
         }
 
-        if (!REGEX_EXTERNAL_PROTOCOLS.test(path) && path.indexOf('.js') !== path.length - 3) {
+        if (!REGEX_EXTERNAL_PROTOCOLS.test(path) && path.lastIndexOf('.js') !== path.length - 3) {
             path += '.js';
         }
 

--- a/test/fixture/config.js
+++ b/test/fixture/config.js
@@ -72,6 +72,10 @@ module.exports = {
             },
             'path': 'aui-test2.js'
         },
+        'module.js': {
+            'dependencies': [],
+            'path': 'module.js/src/module.js'
+        },
         'liferay@1.0.0': {
             'dependencies': ['exports'],
             'path': 'liferay.js'

--- a/test/url-builder.js
+++ b/test/url-builder.js
@@ -18,6 +18,17 @@ describe('URLBuilder', function () {
         assert.sameMembers(modulesURL[0].modules, ['aui-core']);
     });
 
+    it('should append a .js extension to the path if the extension is missing', function() {
+        var urlBuilder = new global.URLBuilder(configParser);
+
+        var modulesURL = urlBuilder.build(['module.js']);
+
+        assert.strictEqual(modulesURL.length, 1);
+
+        assert.strictEqual(modulesURL[0].url, 'http://localhost:3000/combo?/modules/module.js/src/module.js');
+        assert.sameMembers(modulesURL[0].modules, ['module.js']);
+    });
+
     it('should create URL for module with full path', function () {
         var urlBuilder = new global.URLBuilder(configParser);
 


### PR DESCRIPTION
This is a possible fix for #98 