### PR TITLE
Fix Promise in IE

### DIFF
--- a/src/js/script-loader.js
+++ b/src/js/script-loader.js
@@ -195,6 +195,10 @@ var LoaderProtoMethods = {
 
         var rejectTimeout;
 
+        if (!'Promise' in global && global.ES6Promise) {
+            global.Promise = global.ES6Promise;
+        }
+
         new Promise(function(resolve, reject) {
             // Resolve the dependencies of the requested modules,
             // then load them and resolve the Promise


### PR DESCRIPTION
The `es6-promise` module exposes `ES6Promise` and not `Promise`