### PR TITLE
Updates README to reflect the new ignoreVersions property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 AMD Module Loader
 =====
 
+[![Build Status](https://travis-ci.org/liferay/liferay-amd-loader.svg)](https://travis-ci.org/liferay/liferay-amd-loader)
+
 Supports loading modules via combo URL. Modules can be loaded automatically when some other module is being triggered, but only if some condition is met.
 
 ___Note:___ Loading anonymous modules via combo URL is not possible. If some of the modules is anonymous and `combine` is set to `true`, the module should be registered and `anonymous` property to be set as `true`. In this way this module will be excluded from the combo URL and a separate `script` element will be created for it. If `combine` is set to `false`, describing the module is not needed.
@@ -293,4 +295,7 @@ Exposing Loader globally
 ======
 Setting `exposeGlobal` property of the config will expose the Loader to the window, among with the `define` and `require` functions. By default the value of this property is true. For example, there will be `window.Loader`, `window.require` and `window.define` methods in case `exposeGlobal` is unset or set to true. Otherwise, these will be undefined.
 
-[![Build Status](https://travis-ci.org/liferay/liferay-amd-loader.svg)](https://travis-ci.org/liferay/liferay-amd-loader)
+Ignoring module versions
+======
+Setting `ignoreVersions` property of the config will ignore the `@major.minor.path` version qualifier in a module name to allow for a more lenient module name match in scenarios where undisclosed security vulnerabilities can lead to a security leak if versions are exposed to the
+loader configuration.

--- a/src/js/script-loader.js
+++ b/src/js/script-loader.js
@@ -376,6 +376,15 @@ var LoaderProtoMethods = {
 		var module = config || {};
 		var configParser = this._getConfigParser();
 
+		if (configParser.getConfig().ignoreVersions) {
+			var nameParts = name.split('/');
+			var packageParts = nameParts[0].split('@');
+
+			nameParts[0] = packageParts[0];
+
+			name = nameParts.join('/');
+		}
+
 		var pathResolver = this._getPathResolver();
 
 		// Resolve the path according to the parent module. Example:

--- a/test/fixture/modules/issue-146/ignore-versions.js
+++ b/test/fixture/modules/issue-146/ignore-versions.js
@@ -1,0 +1,3 @@
+define('issue-146@1.0.0/ignoreVersions', ['module'], function(module) {
+	module.exports = 'ignoreVersions';
+});

--- a/test/script-loader.js
+++ b/test/script-loader.js
@@ -132,6 +132,10 @@ describe('Loader', function() {
 					path: 'issue-140/m2/m2.js',
 					dependencies: ['module', 'issue-140/m1'],
 				},
+				'issue-146/ignoreVersions': {
+					dependencies: [],
+					path: 'issue-146/ignore-versions.js',
+				},
 			},
 		};
 
@@ -1114,6 +1118,24 @@ describe('Loader', function() {
 			assert.strictEqual(m2.standard, 'standard:a');
 			assert.strictEqual(m2.local, 'local:a');
 			assert.strictEqual(m2.mapped, 'mapped:a');
+
+			done();
+		}, 50);
+	});
+
+	it('should match module names without the version qualifier when ignoreVersions is set to true (issue 146)', function(
+		done
+	) {
+		var failure = sinon.stub();
+		var success = sinon.stub();
+
+		global.__CONFIG__.ignoreVersions = true;
+
+		Loader.require('issue-146/ignoreVersions', success, failure);
+
+		setTimeout(function() {
+			assert.isTrue(failure.notCalled);
+			assert.isTrue(success.calledOnce);
 
 			done();
 		}, 50);


### PR DESCRIPTION
Hey @ipeychev, how are you doing!?

Can you take a look at this? The rationale behind it can be found in https://github.com/liferay/liferay-amd-loader/issues/146, and it is motivated by a security issue.

What do you think?