### PR TITLE
Add lint plug-in to prevent accidentally committing "only" tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,9 @@
 {
-	"extends": "liferay"
+	"extends": "liferay",
+	"plugins": [
+		"no-only-tests"
+	],
+	"rules": {
+		"no-only-tests/no-only-tests": "error"
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3120,6 +3120,11 @@
         "requireindex": "~1.1.0"
       }
     },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.1.0.tgz",
+      "integrity": "sha512-T02dNNDj7sKJNvH7YLKqgv4+BDupxKG4OgadF0AecDHrYTb9hlosxqCgZbFKt28C7Ueof6ziCtEh6rnPvN4YYA=="
+    },
     "eslint-scope": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "combohandler": "^0.4.0",
     "eslint": "^4.17.0",
     "eslint-config-liferay": "^2.0.18",
+    "eslint-plugin-no-only-tests": "2.1.0",
     "fs-extra": "^5.0.0",
     "globby": "^7.1.1",
     "http-server": "^0.11.1",


### PR DESCRIPTION
Test plan: add an `it.only` then run `npm run lint` and see:

```
/Users/greghurrell/code/liferay-amd-loader/src/loader/__tests__/config.js
  10:5  error  it.only not permitted  no-only-tests/no-only-tests

✖ 1 problem (1 error, 0 warnings)
```