### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-GNU LESSER GENERAL PUBLIC LICENSE 
+GNU LESSER GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 
@@ -20,24 +20,24 @@ The "Minimal Corresponding Source" for a Combined Work means the Corresponding S
 
 The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
 
-1. Exception to Section 3 of the GNU GPL. 
+1. Exception to Section 3 of the GNU GPL.
 You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
 
-2. Conveying Modified Versions. 
+2. Conveying Modified Versions.
 If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
 
 a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
 
 b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
 
-3. Object Code Incorporating Material from Library Header Files. 
+3. Object Code Incorporating Material from Library Header Files.
 The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
 
 a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
 
 b) Accompany the object code with a copy of the GNU GPL and this license document.
 
-4. Combined Works. 
+4. Combined Works.
 You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
 
 a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
@@ -54,17 +54,17 @@ d) Do one of the following:
 
 e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
 
-5. Combined Libraries. 
+5. Combined Libraries.
 You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
 
 a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
 
 b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
 
-6. Revised Versions of the GNU Lesser General Public License. 
+6. Revised Versions of the GNU Lesser General Public License.
 The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
 
 Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
 
-If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall 
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.

--- a/LICENSES/LGPL-3.0-or-later.txt
+++ b/LICENSES/LGPL-3.0-or-later.txt
@@ -1,0 +1,70 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library. The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+
+b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+
+b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+
+b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+d) Do one of the following:
+
+0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+
+1) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+
+e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+
+b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.

--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/bin/build-demo.js
+++ b/bin/build-demo.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/bin/build-loader.js
+++ b/bin/build-loader.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/bin/combo.js
+++ b/bin/combo.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/bin/demo-server.js
+++ b/bin/demo-server.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/bin/run-demo.js
+++ b/bin/run-demo.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/bin/util.js
+++ b/bin/util.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/copyright.js
+++ b/copyright.js
@@ -1,6 +1,5 @@
 /**
- * © <%= YEAR %> Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/.eslintrc.js
+++ b/src/demo/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/config.js
+++ b/src/demo/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/.eslintrc.js
+++ b/src/demo/modules/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/circular@1.0.0/chicken.js
+++ b/src/demo/modules/circular@1.0.0/chicken.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/circular@1.0.0/egg.js
+++ b/src/demo/modules/circular@1.0.0/egg.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/circular@1.0.0/index.js
+++ b/src/demo/modules/circular@1.0.0/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/constants@1.0.0/index.js
+++ b/src/demo/modules/constants@1.0.0/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/isarray@1.0.0/index.js
+++ b/src/demo/modules/isarray@1.0.0/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/isarray@1.1.0/index.js
+++ b/src/demo/modules/isarray@1.1.0/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/demo/modules/isobject@1.0.0/index.js
+++ b/src/demo/modules/isobject@1.0.0/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/.eslintrc.js
+++ b/src/loader/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/.eslintrc.js
+++ b/src/loader/__tests__/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/.eslintrc.js
+++ b/src/loader/__tests__/__fixtures__/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/.eslintrc.js
+++ b/src/loader/__tests__/__fixtures__/loader/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/export-false.js
+++ b/src/loader/__tests__/__fixtures__/loader/export-false.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/export-null.js
+++ b/src/loader/__tests__/__fixtures__/loader/export-null.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/export-undefined.js
+++ b/src/loader/__tests__/__fixtures__/loader/export-undefined.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/issue-140/a.js
+++ b/src/loader/__tests__/__fixtures__/loader/issue-140/a.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/issue-140/m1.js
+++ b/src/loader/__tests__/__fixtures__/loader/issue-140/m1.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/issue-140/m2/m2.js
+++ b/src/loader/__tests__/__fixtures__/loader/issue-140/m2/m2.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/local-require/a.js
+++ b/src/loader/__tests__/__fixtures__/loader/local-require/a.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/local-require/failure.js
+++ b/src/loader/__tests__/__fixtures__/loader/local-require/failure.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/local-require/rel-path.js
+++ b/src/loader/__tests__/__fixtures__/loader/local-require/rel-path.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/local-require/sync.js
+++ b/src/loader/__tests__/__fixtures__/loader/local-require/sync.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/local-require/to-url.js
+++ b/src/loader/__tests__/__fixtures__/loader/local-require/to-url.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/say-goodbye.js
+++ b/src/loader/__tests__/__fixtures__/loader/say-goodbye.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/__fixtures__/loader/say-hello.js
+++ b/src/loader/__tests__/__fixtures__/loader/say-hello.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/config.js
+++ b/src/loader/__tests__/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/dependency-resolver.js
+++ b/src/loader/__tests__/dependency-resolver.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/loader.js
+++ b/src/loader/__tests__/loader.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/logger.js
+++ b/src/loader/__tests__/logger.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/module.js
+++ b/src/loader/__tests__/module.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/resolvable-promise.js
+++ b/src/loader/__tests__/resolvable-promise.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/script-loader.js
+++ b/src/loader/__tests__/script-loader.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/__tests__/url-builder.js
+++ b/src/loader/__tests__/url-builder.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/bootstrap.js
+++ b/src/loader/bootstrap.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/config.js
+++ b/src/loader/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/dependency-resolver.js
+++ b/src/loader/dependency-resolver.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/logger.js
+++ b/src/loader/logger.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/module.js
+++ b/src/loader/module.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/resolvable-promise.js
+++ b/src/loader/resolvable-promise.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/script-loader.js
+++ b/src/loader/script-loader.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/loader/url-builder.js
+++ b/src/loader/url-builder.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/webpack.proxyPortal.js
+++ b/webpack.proxyPortal.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 


### PR DESCRIPTION
This change is analogous to the one I made in:

- https://github.com/liferay/eslint-config-liferay/pull/151
- https://github.com/liferay/liferay-npm-tools/pull/394
- https://github.com/liferay/liferay-js-themes-toolkit/pull/441
- https://github.com/liferay/clay/pull/2947
- https://github.com/liferay/alloy-editor/pull/1382

It updates the license header format to match the latest policy:

https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Did this by updating `copyright.js` and running `yarn lint:fix`. I used a Vim macro to strip out the original headers and preserve the original copyright dates.

Adds a copy of the license to `LICENSES/LGPL-3.0-or-later.txt` as required by the policy too.