### PR TITLE
chore: configure dependabot to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+# Configuration for the GitHub's Dependabot.
+#
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - directory: "/"
+    open-pull-requests-limit: 1
+    package-ecosystem: "npm"
+    rebase-strategy: "disabled"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This is analogous to the PR in liferay-npm-tools here:

https://github.com/liferay/liferay-npm-tools/pull/490

Copying the rationale here:

> Dependabot spams us with update PRs that we don't want to merge because of the reasons described here:
>
> https://github.com/liferay/liferay-frontend-guidelines/blob/master/general/security.md
>
> Most importantly, there are drawbacks to lockfile-only updates (they are too easily reverted or misunderstood, for example) and we prefer to batch our security updates together based on some human assessment of impact/urgency etc.
>
> So, this setting file should ensure that Dependabot only keeps at most one PR open at a time (the default is 10, I believe), and it runs weekly (the default, I believe). Additionally, given that we want these PRs only as a cue for a human to schedule a periodic manual audit, we turn off automatic rebasing to further reduce noise.
>
> Test plan: Sadly, I don't think I can test it, short of shipping it and then monitoring. At the moment we have 6 dependency update PRs open in this repo. I'll close them and replace them with a manual update ticket, and then we'll have to watch and see whether the PR count stays at 1 or below.